### PR TITLE
use uppercase UTF-8 in URLEncoder.encode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
   organization := "com.github.mliarakos.lagomjs",
-  version := s"0.1.0-$baseLagomVersion"
+  version := s"0.2.0-$baseLagomVersion-SNAPSHOT"
 )
 
 lazy val commonJsSettings = Seq(

--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
@@ -51,7 +51,8 @@ private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
           queryParams
             .flatMap {
               case (name, values) =>
-                values.map(value => URLEncoder.encode(name, "utf-8") + "=" + URLEncoder.encode(value, "utf-8"))
+                // URLEncoder is implemented by akka.js, which expects an uppercase UTF-8 compared to the case insensitive JVM as used in the original lagom sources
+                values.map(value => URLEncoder.encode(name, "UTF-8") + "=" + URLEncoder.encode(value, "UTF-8"))
             }
             .mkString("?", "&", "")
         } else ""


### PR DESCRIPTION
Well that took a while to hunt down ;)

The [java.net.URLEncoder](https://github.com/akka-js/akka.js/blob/441c60a978227916d593880de9cd89c53e9b1bb3/akka-js-actor/js/src/main/scala/java/net/URLEncoder.scala) used here is implemented by akka.js and expects an upper case UTF-8, throwing an exception otherwise. The JVM version is case insensitive. It would probably be cleaner to fix it in akka.js itself or even provide a proper implementation in scala.js, but for now it should do the job.

This issue only arises when using query parameters in `pathCall` e.g.:
```scala
pathCall("/api/call?parameter", call _),
```

I've also raised the version to 0.2-*-SNAPSHOT, hope that's ok.