### PR TITLE
Scalajs 1.0 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 val scalaVersions = Seq("2.12.10", "2.13.1")
 
 val baseLagomVersion = "1.6.2"
-val akkaJsVersion    = "2.2.6.3"
+val akkaJsVersion    = "2.2.6.5"
 
 lazy val scalaSettings = Seq(
   crossScalaVersions := scalaVersions,
@@ -54,11 +54,7 @@ lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
 )
 
 lazy val commonJsSettings = Seq(
-  jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
-  scalacOptions ++= {
-    if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
-    else Nil
-  }
+  jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
 )
 
 lazy val lagomVersion         = settingKey[String]("The Lagom version to use.")
@@ -142,7 +138,7 @@ lazy val `lagomjs-api` = crossProject(JSPlatform)
       "org.akka-js"            %%% "akkajsactor"              % akkaJsVersion,
       "org.akka-js"            %%% "akkajsactorstream"        % akkaJsVersion,
       "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.1.2",
-      "com.typesafe.play"      %%% "play-json"                % "2.8.1"
+      "com.typesafe.play"      %%% "play-json"                % "2.9.0"
     )
   )
   .jsSettings(
@@ -186,7 +182,7 @@ lazy val `lagomjs-api-scaladsl` = crossProject(JSPlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-      "org.scalatest"  %%% "scalatest"   % "3.0.8"            % Test
+      "org.scalatest"  %%% "scalatest"   % "3.1.2"            % Test
     )
   )
   .jsSettings(
@@ -251,7 +247,7 @@ lazy val `lagomjs-client` = crossProject(JSPlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "org.scala-js"  %%% "scalajs-dom" % "1.0.0",
-      "org.scalatest" %%% "scalatest"   % "3.0.8" % Test
+      "org.scalatest" %%% "scalatest"   % "3.1.2" % Test
     )
   )
   .jsSettings(
@@ -297,7 +293,7 @@ lazy val `lagomjs-client-scaladsl` = crossProject(JSPlatform)
   .jsSettings(commonJsSettings: _*)
   .jsSettings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.8" % Test
+      "org.scalatest" %%% "scalatest" % "3.1.2" % Test
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,10 @@ lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
 
 lazy val commonJsSettings = Seq(
   jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
-  scalacOptions += "-P:scalajs:sjsDefinedByDefault"
+  scalacOptions ++= {
+    if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
+    else Nil
+  }
 )
 
 lazy val lagomVersion         = settingKey[String]("The Lagom version to use.")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.0.1")
 
 addSbtPlugin("com.jsuereth"  % "sbt-pgp"      % "1.1.1")
-addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "0.5.0")
+addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "1.0.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,11 @@
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.33")
-
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.0.1")
 
 addSbtPlugin("com.jsuereth"  % "sbt-pgp"      % "1.1.1")
 addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "0.5.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 
 libraryDependencies ++= Seq(
-  "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.1.201504261725-r"
-) ++ {
-  if (scalaJSVersion.startsWith("0.6.")) Nil
-  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
-}
+  "org.eclipse.jgit" % "org.eclipse.jgit.pgm"      % "3.7.1.201504261725-r",
+  "org.scala-js"     %% "scalajs-env-jsdom-nodejs" % "1.1.0"
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.33")
+
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.33")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
 
 addSbtPlugin("com.jsuereth"  % "sbt-pgp"      % "1.1.1")
 addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "0.5.0")
@@ -7,4 +9,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 
 libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.1.201504261725-r"
-)
+) ++ {
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
+}


### PR DESCRIPTION
Initial support to cross compile with Scala.js 1.0 using an environment variable as described in the Scala.js 1.0.0 [release notes](https://www.scala-js.org/news/2020/02/25/announcing-scalajs-1.0.0).

Waiting on Scala.js 1.0 support from:
- `play-json`: see https://github.com/playframework/play-json/pull/433
- `akka.js`: see https://github.com/akka-js/akka.js/pull/118