### PR TITLE
Fix client ajax timeout exception

### DIFF
--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
@@ -283,7 +283,7 @@ private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
         responseType = ""
       )
       .recover({
-        case AjaxException(xhr) => xhr
+        case e: AjaxException if !e.isTimeout => e.xhr
       })
       .map(xhr => {
         val status  = xhr.status


### PR DESCRIPTION
Preserve the `AjaxException` if it's a timeout, otherwise unpack it and attempt to deserialize an exception per normal.

Fixes #15.