### PR TITLE
fixed delay between websocket connection and .onmessage subscription …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lagom.js is built against specific versions of Lagom, the latest are:
 |-------------|-------|-----------------|----------|
 | 0.1.2-1.5.5 | 1.5.5 | 2.11 <br> 2.12  | 0.6.31   |
 | 0.3.2-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 0.6.33   |
-| 0.4.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.4.1-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 
 Lagom.js moved to Scala.js 1.x starting with version `0.4.0-1.6.2`. Scala.js 0.6 is no longer supported, the last version to support it was `0.3.2-1.6.2`. For all past releases, see [releases](#Releases).
 
@@ -27,7 +27,7 @@ Lagom.js provides JavaScript versions of several Lagom artifacts. The two most i
 The `lagomjs-scaladsl-api` artifact provides the JavaScript implementation of the Lagom service API:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.0-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.1-1.6.4"
 ```
 
 To use it you'll need to configure your service API as a [Scala.js cross project](https://github.com/portable-scala/sbt-crossproject) for the JVM and JS platforms. Then, add the `lagomjs-scaladsl-api` dependency to the JS platform:
@@ -39,7 +39,7 @@ lazy val `service-api` = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies += lagomScaladslApi
   )
   .jsSettings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.0-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.1-1.6.4"
   )
 ```
 
@@ -50,7 +50,7 @@ This enables your Lagom service definition to be compiled into JavaScript. In ad
 The `lagomjs-scaladsl-client` artifact provides the JavaScript implementation of the Lagom service client:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.0-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.1-1.6.4"
 ```
 
 You can use it in a Scala.js project along with your service API to generate a service client:
@@ -58,7 +58,7 @@ You can use it in a Scala.js project along with your service API to generate a s
 ```scala
 lazy val `client-js` = project
   .settings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.0-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.1-1.6.4"
   )
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(`service-api`.js)
@@ -80,6 +80,9 @@ However, the service client does not support a few the features available in Lag
 - subscribing to topics: topic definitions are available in the service client, but attempting to subscribe to the topic throws an exception
 - advanced service locators: service locators outside of the built-in service locators, such as `AkkaDiscoveryServiceLocator`, are not available
 
+## Known issues
+`ServiceCalls` based on akka-stream `Source` are implemented using Websockets, which don't propagate backpressure. This might change with [WebSocketStream API](https://web.dev/websocketstream/) once it's widely available.
+
 ## Releases
 
 Lagom.js tracks Lagom and generally doesn't continue development on previous Lagom releases. Since Lagom maintains a stable API within a minor release (e.g., 1.6.x) any version of Lagom.js built for that minor release should work. However, if you need Lagom.js for a specific previous Lagom release the previous Lagom.js releases are listed below. If you have an issue with a previous Lagom.js release please open an [issue](https://github.com/mliarakos/lagom-js/issues) and it will be considered on a case-by-case basis.
@@ -96,4 +99,5 @@ Lagom.js tracks Lagom and generally doesn't continue development on previous Lag
 | 0.4.0-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 1.0.1    |
 | 0.4.0-1.6.3 | 1.6.3 | 2.12 <br> 2.13  | 1.1.1    |
 | 0.4.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.4.1-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lagom.js is built against specific versions of Lagom, the latest are:
 |-------------|-------|-----------------|----------|
 | 0.1.2-1.5.5 | 1.5.5 | 2.11 <br> 2.12  | 0.6.31   |
 | 0.3.2-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 0.6.33   |
-| 0.4.1-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.5.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 
 Lagom.js moved to Scala.js 1.x starting with version `0.4.0-1.6.2`. Scala.js 0.6 is no longer supported, the last version to support it was `0.3.2-1.6.2`. For all past releases, see [releases](#Releases).
 
@@ -27,7 +27,7 @@ Lagom.js provides JavaScript versions of several Lagom artifacts. The two most i
 The `lagomjs-scaladsl-api` artifact provides the JavaScript implementation of the Lagom service API:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.1-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.4"
 ```
 
 To use it you'll need to configure your service API as a [Scala.js cross project](https://github.com/portable-scala/sbt-crossproject) for the JVM and JS platforms. Then, add the `lagomjs-scaladsl-api` dependency to the JS platform:
@@ -39,7 +39,7 @@ lazy val `service-api` = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies += lagomScaladslApi
   )
   .jsSettings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.4.1-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.4"
   )
 ```
 
@@ -50,7 +50,7 @@ This enables your Lagom service definition to be compiled into JavaScript. In ad
 The `lagomjs-scaladsl-client` artifact provides the JavaScript implementation of the Lagom service client:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.1-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.4"
 ```
 
 You can use it in a Scala.js project along with your service API to generate a service client:
@@ -58,7 +58,7 @@ You can use it in a Scala.js project along with your service API to generate a s
 ```scala
 lazy val `client-js` = project
   .settings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.4.1-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.4"
   )
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(`service-api`.js)
@@ -132,5 +132,4 @@ Lagom.js tracks Lagom and generally doesn't continue development on previous Lag
 | 0.4.0-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 1.0.1    |
 | 0.4.0-1.6.3 | 1.6.3 | 2.12 <br> 2.13  | 1.1.1    |
 | 0.4.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
-| 0.4.1-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
-
+| 0.5.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
   organization := "com.github.mliarakos.lagomjs",
-  version := s"0.4.1-$baseLagomVersion-SNAPSHOT"
+  version := s"0.5.0-$baseLagomVersion-SNAPSHOT"
 )
 
 lazy val commonJsSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -232,12 +232,6 @@ lazy val `lagomjs-client` = crossProject(JSPlatform)
         sourceTarget
       )
 
-      val resourcesTarget = file("lagomjs-client") / "js" / "src" / "main" / "resources"
-      copyToSourceDirectory(
-        lagomTargetDirectory.value / "service" / "core" / "client" / "src" / "main" / "resources",
-        resourcesTarget
-      )
-
       val jsSources = sourceDirectory.value / "main" / "scala"
       applyOverrides(sourceTarget, jsSources)
     },

--- a/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslWebSocketClient.scala
+++ b/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslWebSocketClient.scala
@@ -1,9 +1,11 @@
 package com.lightbend.lagom.internal.scaladsl.client
 
+import akka.stream.Materializer
 import com.lightbend.lagom.internal.client.WebSocketClient
+import com.typesafe.config.Config
 
 import scala.concurrent.ExecutionContext
 
-private[lagom] class ScaladslWebSocketClient()(implicit ec: ExecutionContext)
-    extends WebSocketClient()(ec)
+private[lagom] class ScaladslWebSocketClient(config : Config)(implicit ec: ExecutionContext, materializer: Materializer)
+    extends WebSocketClient(config)(ec, materializer)
     with ScaladslServiceApiBridge

--- a/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslWebSocketClient.scala
+++ b/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslWebSocketClient.scala
@@ -2,10 +2,12 @@ package com.lightbend.lagom.internal.scaladsl.client
 
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.client.WebSocketClient
-import com.typesafe.config.Config
+import com.lightbend.lagom.internal.client.WebSocketClientConfig
 
 import scala.concurrent.ExecutionContext
 
-private[lagom] class ScaladslWebSocketClient(config : Config)(implicit ec: ExecutionContext, materializer: Materializer)
-    extends WebSocketClient(config)(ec, materializer)
+private[lagom] class ScaladslWebSocketClient(config: WebSocketClientConfig)(
+    implicit ec: ExecutionContext,
+    materializer: Materializer
+) extends WebSocketClient(config)(ec, materializer)
     with ScaladslServiceApiBridge

--- a/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
+++ b/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
@@ -136,7 +136,8 @@ trait LagomServiceClientComponents extends TopicFactoryProvider { self: LagomCon
   lazy val serviceResolver: ServiceResolver                = new ScaladslServiceResolver(defaultExceptionSerializer)
   lazy val defaultExceptionSerializer: ExceptionSerializer = new DefaultExceptionSerializer(environment)
 
-  lazy val scaladslWebSocketClient: ScaladslWebSocketClient = new ScaladslWebSocketClient()(executionContext)
+  lazy val scaladslWebSocketClient: ScaladslWebSocketClient =
+    new ScaladslWebSocketClient(config)(executionContext, materializer)
   lazy val serviceClient: ServiceClient = new ScaladslServiceClient(
     scaladslWebSocketClient,
     serviceInfo,

--- a/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
+++ b/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
@@ -11,6 +11,7 @@ import akka.actor.CoordinatedShutdown
 import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.client.WebSocketClientConfig
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactoryProvider
 import com.lightbend.lagom.internal.scaladsl.client.ScaladslClientMacroImpl
 import com.lightbend.lagom.internal.scaladsl.client.ScaladslServiceClient
@@ -137,7 +138,7 @@ trait LagomServiceClientComponents extends TopicFactoryProvider { self: LagomCon
   lazy val defaultExceptionSerializer: ExceptionSerializer = new DefaultExceptionSerializer(environment)
 
   lazy val scaladslWebSocketClient: ScaladslWebSocketClient =
-    new ScaladslWebSocketClient(config)(executionContext, materializer)
+    new ScaladslWebSocketClient(WebSocketClientConfig(config))(executionContext, materializer)
   lazy val serviceClient: ServiceClient = new ScaladslServiceClient(
     scaladslWebSocketClient,
     serviceInfo,

--- a/lagomjs-client/js/src/main/resources/reference.conf
+++ b/lagomjs-client/js/src/main/resources/reference.conf
@@ -45,7 +45,8 @@ lagom.client.websocket {
   }
 
   # Size of the internal WebSocket data receive buffer used to
-  # compensate for the lack of back-pressue in JavaScript WebSockets.
-  bufferSize = 1024
+  # compensate for the delay between WebSocket connection and stream
+  # start.
+  bufferSize = 16
 }
 #//#web-socket-client-default

--- a/lagomjs-client/js/src/main/resources/reference.conf
+++ b/lagomjs-client/js/src/main/resources/reference.conf
@@ -1,0 +1,51 @@
+#//#circuit-breaker-default
+# Circuit breakers for calls to other services are configured
+# in this section. A child configuration section with the same
+# name as the circuit breaker identifier will be used, with fallback
+# to the `lagom.circuit-breaker.default` section.
+lagom.circuit-breaker {
+
+  # Default configuration that is used if a configuration section
+  # with the circuit breaker identifier is not defined.
+  default {
+    # Possibility to disable a given circuit breaker.
+    enabled = on
+
+    # Number of failures before opening the circuit.
+    max-failures = 10
+
+    # Duration of time after which to consider a call a failure.
+    call-timeout = 10s
+
+    # Duration of time in open state after which to attempt to close
+    # the circuit, by first entering the half-open state.
+    reset-timeout = 15s
+
+    # A whitelist of fqcn of Exceptions that the CircuitBreaker
+    # should not consider failures. By default all exceptions are
+    # considered failures.
+    exception-whitelist = []
+  }
+}
+#//#circuit-breaker-default
+
+#//#web-socket-client-default
+# This configures the websocket clients used by this service.
+# This is a global configuration and it is currently not possible
+# to provide different configurations if multiple websocket services
+# are consumed.
+lagom.client.websocket {
+
+  # This parameter limits the allowed maximum size for the messages
+  # flowing through the WebSocket. A similar limit exists on
+  # the server side, see:
+  # https://www.playframework.com/documentation/2.6.x/ScalaWebSockets#Configuring-WebSocket-Frame-Length
+  frame {
+    maxLength = 65536
+  }
+
+  # Size of the internal WebSocket data receive buffer used to
+  # compensate for the lack of back-pressue in JavaScript WebSockets.
+  bufferSize = 1024
+}
+#//#web-socket-client-default

--- a/lagomjs-client/js/src/main/resources/reference.conf
+++ b/lagomjs-client/js/src/main/resources/reference.conf
@@ -36,18 +36,10 @@ lagom.circuit-breaker {
 # are consumed.
 lagom.client.websocket {
 
-  # This parameter limits the allowed maximum size for the messages
-  # flowing through the WebSocket. A similar limit exists on
-  # the server side, see:
-  # https://www.playframework.com/documentation/2.6.x/ScalaWebSockets#Configuring-WebSocket-Frame-Length
-  frame {
-    maxLength = 65536
-  }
-
   # Size of the internal WebSocket data receive buffer used to
   # compensate for the delay between WebSocket connection and stream
-  # start.
-  # Set to "unlimited" for an ulimited buffer size.
+  # start and for the lack of WebSocket back-pressure.
+  # Set to "unlimited" for an effectively ulimited buffer size.
   bufferSize = 16
 }
 #//#web-socket-client-default

--- a/lagomjs-client/js/src/main/resources/reference.conf
+++ b/lagomjs-client/js/src/main/resources/reference.conf
@@ -47,6 +47,7 @@ lagom.client.websocket {
   # Size of the internal WebSocket data receive buffer used to
   # compensate for the delay between WebSocket connection and stream
   # start.
+  # Set to "unlimited" for an ulimited buffer size.
   bufferSize = 16
 }
 #//#web-socket-client-default

--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketStreamBuffer.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketStreamBuffer.scala
@@ -10,14 +10,38 @@ import scala.collection.mutable
 import scala.scalajs.js.typedarray.ArrayBuffer
 import scala.scalajs.js.typedarray.TypedArrayBuffer
 
+/**
+ * Buffers elements received from a WebSocket for consumption by a reactive stream
+ *
+ * The buffer is implemented as a finite state machine for use in a JavaScript runtime. It prioritizes delivering
+ * elements downstream immediately in response to incoming messages and downstream requests. This is to mitigate the
+ * impact of fast sockets consuming the event-loop and preventing downstream consumption of messages. It enforces a
+ * maximum number of queued elements and will fail the socket and stream if the maximum is exceeded.
+ *
+ * The buffer has seven states: Queueing, Full, Streaming, Draining, Completed, Cancelled, and Failed.
+ *
+ * The Queueing state is when the socket is open, the buffer will receive and queue messages, and no subscriber
+ * has been attached. The Full state is when the socket is closed, the buffer will not queue more messages, and no
+ * subscriber has been attached. The Streaming state is when the socket is open, the buffer will receive and queue
+ * messages, a subscriber is attached, and messages are sent to the subscriber in response to its demand signals. The
+ * Draining state is when the socket is closed, the buffer will not queue more messages, a subscriber is attached, and
+ * messages are sent to the subscriber in response to its demand signals. The Completed state is when the socket is
+ * closed, a subscriber is attached, all queued messages have been sent to the subscriber, and the subscriber is
+ * completed. The Cancelled state is when a subscriber is attached and cancelled, causing the socket to be closed and
+ * any queued messages to be discarded. The Failed state is when the buffer has failed for any reason, causing the
+ * socket to be closed, the subscriber to be completed with an error, and any queued messages to be discarded.
+ */
 private[lagom] class WebSocketStreamBuffer(
     socket: WebSocket,
     bufferSize: Int,
     deserializeException: (Int, ByteString) => Throwable
 ) {
+  // Start the buffer in the Queueing state
   private var state: State = Queueing(bufferSize)(this, socket)
 
-  // Forward messages from the socket to the buffer
+  // Configure the socket to interact with the buffer
+
+  // Add messages from the socket to the queue
   socket.onmessage = { message =>
     // The message data should be either an ArrayBuffer or a String
     // It should not be a Blob because the socket binaryType was set
@@ -38,7 +62,7 @@ private[lagom] class WebSocketStreamBuffer(
   // The buffer will ensure that pending elements are delivered before downstream completion
   socket.onclose = { event =>
     if (event.code == NormalClosure) {
-      this.close()
+      this.complete()
     } else {
       // Fail because the socket closed with an error
       // Parse the error reason as an exception
@@ -48,13 +72,18 @@ private[lagom] class WebSocketStreamBuffer(
     }
   }
 
+  // Delegate all operations to the current state
+
+  def isSubscribed: Boolean                                 = state.isSubscribed
   def attach(subscriber: Subscriber[_ >: ByteString]): Unit = state.attach(subscriber)
   def addDemand(n: Long): Unit                              = state.addDemand(n)
+  def cancel(): Unit                                        = state.cancel()
 
   private def enqueue(message: ByteString): Unit = state.enqueue(message)
-  private def close(): Unit                      = state.close()
+  private def complete(): Unit                   = state.complete()
   private def error(exception: Throwable): Unit  = state.error(exception)
 
+  // Internal method used by the state to transition to a new sate
   private def transition(next: State): Unit = state = next
 }
 
@@ -63,27 +92,100 @@ private object WebSocketStreamBuffer {
   val ApplicationFailureCode = 4000
 
   sealed trait State {
+
+    /**
+     * Indicates whether the state has a subscriber
+     *
+     * @return true if subscribed, otherwise false
+     */
+    def isSubscribed: Boolean
+
+    /**
+     * Add the given message to the queue
+     *
+     * @param message the message to add
+     */
     def enqueue(message: ByteString): Unit
+
+    /**
+     * Attach a reactive streams subscriber
+     *
+     * @param subscriber the subscriber
+     */
     def attach(subscriber: Subscriber[_ >: ByteString]): Unit
+
+    /**
+     * Add given demand to the outstanding demand
+     *
+     * It is called by the reactive streams Subscriber via its Subscription `request` method
+     *
+     * @param n the demand
+     */
     def addDemand(n: Long): Unit
-    def close(): Unit
+
+    /**
+     * Complete the buffer
+     *
+     * This indicates that no new elements will be added to the buffer. It is called when the socket closes
+     * successfully.
+     */
+    def complete(): Unit
+
+    /**
+     * Cancel the buffer
+     *
+     * It is called by the reactive streams Subscriber via its Subscription `cancel` method
+     */
+    def cancel(): Unit
+
+    /**
+     * Error the buffer with the given exception
+     *
+     * This is called in a variety of error conditions, including when the socket closes with an error.
+     *
+     * @param exception the exception
+     */
     def error(exception: Throwable): Unit
+
   }
 
+  /**
+   * Provides reusable state method to check if adding an element would exceed the buffer size
+   */
   sealed trait QueueSize {
     def bufferSize: Int
     def queue: mutable.Queue[ByteString]
 
+    /**
+     * Check if adding an element would exceed the buffer size, if so returns `Some` exception, otherwise `None`
+     *
+     * The exception is not thrown in order to avoid exception overhead and because the exception must be passed to
+     * the subscriber onError method.
+     *
+     * @return optional exception if the buffer size is exceeded
+     */
     protected def checkSize: Option[Throwable] = {
       if ((queue.size + 1) > bufferSize) Some(BufferOverflowException(s"Exceeded buffer size of $bufferSize"))
       else None
     }
   }
 
+  /**
+   * Provides reusable state method to fulfill subscriber demand
+   */
   sealed trait Fulfill {
     def queue: mutable.Queue[ByteString]
     def subscriber: Subscriber[_ >: ByteString]
 
+    /**
+     * Fulfill subscriber demand if possible
+     *
+     * Fulfill by removing up to demand number of elements elements from the buffer and sending them to the subscriber.
+     * The remaining outstanding demand is returned based on how elements where sent.
+     *
+     * @param demand current demand
+     * @return remaining demand
+     */
     protected def fulfill(demand: Long): Long = {
       val num = Math.min(queue.size, demand)
       for (_ <- 1L to num) subscriber.onNext(queue.dequeue)
@@ -92,11 +194,39 @@ private object WebSocketStreamBuffer {
     }
   }
 
+  /**
+   * Provides reusable state method to cancel the buffer
+   */
+  sealed trait Cancelable {
+    def socket: WebSocket
+    def buffer: WebSocketStreamBuffer
+
+    def cancel(): Unit = {
+      val cancelled = Cancelled()(socket)
+      buffer.transition(cancelled)
+    }
+  }
+
+  /**
+   * State when the socket is open, the buffer will receive and queue messages, and no subscriber has been attached
+   *
+   * This state allows elements to be buffered before the stream is set up and a subscriber is attached. If the socket
+   * closes and the buffer completes before a subscriber is attached then the state will transition to Full.
+   * Otherwise, if a subscriber is attached first, the state will transition to Streaming.
+   */
   case class Queueing(bufferSize: Int)(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
       extends State
       with QueueSize {
     val queue: mutable.Queue[ByteString] = mutable.Queue.empty
 
+    override def isSubscribed: Boolean = false
+
+    /**
+     * Add message to the queue
+     *
+     * If adding the message would exceed the buffer size then the message is discarded and the buffer transitions to
+     * the Failed state.
+     */
     override def enqueue(message: ByteString): Unit = {
       checkSize.fold[Unit]({
         queue.enqueue(message)
@@ -106,66 +236,142 @@ private object WebSocketStreamBuffer {
       })
     }
 
+    /**
+     * Attach the given subscriber and transition to the Streaming state
+     */
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
       val streaming = Streaming(queue, bufferSize, subscriber)
       buffer.transition(streaming)
     }
 
+    /**
+     * Transition to the Failed state because this operation is not supported when no subscriber is attached
+     */
     override def addDemand(n: Long): Unit = {
       val exception = new UnsupportedOperationException("No subscriber is attached")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
-    override def close(): Unit = {
+    /**
+     * Transition to the Full state
+     *
+     * This indicates that no new elements will be added to the buffer. Since the buffer was completed before a
+     * subscriber was attached the buffer contains every message.
+     */
+    override def complete(): Unit = {
       val full = Full(queue)
       buffer.transition(full)
     }
 
+    /**
+     * Transition to the Failed state because this operation is not supported when no subscriber is attached
+     */
+    override def cancel(): Unit = {
+      val exception = new UnsupportedOperationException("No subscriber is attached")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    /**
+     * Error the buffer by transitioning to the Failed state with the given exception
+     */
     override def error(exception: Throwable): Unit = {
       val failed = Failed(exception)
       buffer.transition(failed)
     }
   }
 
+  /**
+   * State when the socket is closed, the buffer will not queue more messages, and no subscriber has been attached
+   *
+   * When a subscriber is attached the state will transition to Draining to start emptying the queue by sending
+   * elements to the subscriber in response to its demand signals. The queue contains all messages ever sent by the
+   * socket because the socket closed and the buffer was completed before a subscriber was attached. The queue may
+   * be empty.
+   */
   case class Full(queue: mutable.Queue[ByteString])(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
       extends State {
 
+    override def isSubscribed: Boolean = false
+
+    /**
+     * Transition to the Failed state because this operation is not supported after the buffer is completed
+     */
     override def enqueue(message: ByteString): Unit = {
-      val exception = new UnsupportedOperationException("Can not add messages after the buffer is closed")
+      val exception = new UnsupportedOperationException("Can not add messages after the buffer is completed")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
+    /**
+     * Attach the given subscriber and transition to the Draining state
+     */
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
       val draining = Draining(queue, subscriber)
       buffer.transition(draining)
     }
 
+    /**
+     * Transition to the Failed state because this operation is not supported when no subscriber is attached
+     */
     override def addDemand(n: Long): Unit = {
       val exception = new UnsupportedOperationException("No subscriber is attached")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
-    override def close(): Unit = {}
+    /**
+     * Ignore because the buffer is already completed
+     */
+    override def complete(): Unit = {}
 
+    /**
+     * Transition to the Failed state because this operation is not supported when no subscriber is attached
+     */
+    override def cancel(): Unit = {
+      val exception = new UnsupportedOperationException("No subscriber is attached")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    /**
+     * Error the buffer by transitioning to the Failed state with the given exception
+     */
     override def error(exception: Throwable): Unit = {
       val failed = Failed(exception)
       buffer.transition(failed)
     }
   }
 
+  /**
+   * State when the socket is open, the buffer will receive and queue messages, a subscriber is attached, and messages
+   * are sent to the subscriber in response to its demand signals
+   *
+   * This state streams messages from the socket to the subscriber via the queue. Messages are sent to the subscriber
+   * in response to its demand signals. When the socket closes and the buffer completes, then the state will transition
+   * to Draining if there are message left in the queue, or Completed if there are no messages left.
+   */
   case class Streaming(
       queue: mutable.Queue[ByteString],
       bufferSize: Int,
       subscriber: Subscriber[_ >: ByteString]
-  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+  )(implicit val buffer: WebSocketStreamBuffer, val socket: WebSocket)
       extends State
       with QueueSize
-      with Fulfill {
+      with Fulfill
+      with Cancelable {
+    // Cumulative outstanding demand starting at 0
     private var demand = 0L
 
+    override def isSubscribed: Boolean = true
+
+    /**
+     * Add message to the queue and fulfill demand is possible
+     *
+     * If adding the message would exceed the buffer size then the message is discarded and the buffer transitions to
+     * the Failed state.
+     */
     override def enqueue(message: ByteString): Unit = {
       checkSize.fold[Unit]({
         queue.enqueue(message)
@@ -176,17 +382,32 @@ private object WebSocketStreamBuffer {
       })
     }
 
+    /**
+     * Transition to the Failed state because this operation is not supported when a subscriber is already attached
+     */
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
       val exception = new UnsupportedOperationException("Buffer already has attached subscriber")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
+    /**
+     * Add and fulfill demand if possible
+     */
     override def addDemand(n: Long): Unit = {
-      demand = fulfill(demand + n)
+      if (n > 0) {
+        demand = fulfill(demand + n)
+      } else {
+        val exception = new IllegalArgumentException(s"Demand of $n is not positive")
+        val failed    = Failed(exception)
+        buffer.transition(failed)
+      }
     }
 
-    override def close(): Unit = {
+    /**
+     * Transition to the Draining state if there are messages in the queue or the Completed state if not
+     */
+    override def complete(): Unit = {
       val state: State = {
         if (queue.nonEmpty) Draining(queue, subscriber, demand)
         else Completed(subscriber)
@@ -194,58 +415,99 @@ private object WebSocketStreamBuffer {
       buffer.transition(state)
     }
 
+    /**
+     * Error the buffer by transitioning to the Failed state with the given exception
+     */
     override def error(exception: Throwable): Unit = {
       val failed = Failed(exception, Some(subscriber))
       buffer.transition(failed)
     }
   }
 
+  /**
+   * State when the socket is closed, the buffer will not queue more messages, a subscriber is attached, and messages
+   * are sent to the subscriber in response to its demand signals
+   *
+   * This state drains the queue by sending messages to the subscriber in response to its demand signals until the
+   * queue is empty and it then transitions to Completed.
+   */
   case class Draining(
       queue: mutable.Queue[ByteString],
       subscriber: Subscriber[_ >: ByteString],
       initialDemand: Long = 0L
-  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+  )(implicit val buffer: WebSocketStreamBuffer, val socket: WebSocket)
       extends State
-      with Fulfill {
+      with Fulfill
+      with Cancelable {
     private var demand = initialDemand
 
+    override def isSubscribed: Boolean = true
+
+    /**
+     * Transition to the Failed state because this operation is not supported after the buffer is completed
+     */
     override def enqueue(message: ByteString): Unit = {
       val exception = new UnsupportedOperationException("Can not add messages after the buffer is closed")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
+    /**
+     * Transition to the Failed state because this operation is not supported when a subscriber is already attached
+     */
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
       val exception = new UnsupportedOperationException("Buffer already has attached subscriber")
       val failed    = Failed(exception)
       buffer.transition(failed)
     }
 
+    /**
+     * Add and fulfill demand if possible, completing the buffer if the queue becomes empty
+     */
     override def addDemand(n: Long): Unit = {
-      demand = fulfill(demand + n)
-      if (queue.isEmpty) {
-        val completed = Completed(subscriber)
-        buffer.transition(completed)
+      if (n > 0) {
+        demand = fulfill(demand + n)
+        if (queue.isEmpty) {
+          val completed = Completed(subscriber)
+          buffer.transition(completed)
+        }
+      } else {
+        val exception = new IllegalArgumentException(s"Demand of $n is not positive")
+        val failed    = Failed(exception)
+        buffer.transition(failed)
       }
     }
 
-    override def close(): Unit = {}
+    /**
+     * Ignore because the buffer is already completed
+     */
+    override def complete(): Unit = {}
 
+    /**
+     * Error the buffer by transitioning to the Failed state with the given exception
+     */
     override def error(exception: Throwable): Unit = {
       val failed = Failed(exception, Some(subscriber))
       buffer.transition(failed)
     }
   }
 
-  case class Completed(subscriber: Subscriber[_])(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
-      extends State {
+  /**
+   * State when the socket is closed, a subscriber is attached, all queued messages have been sent to the subscriber,
+   * and the subscriber is completed
+   *
+   * This is the successful terminal state. Transitioning to this state closes the socket and completes the subscriber.
+   */
+  case class Completed(subscriber: Subscriber[_])(implicit socket: WebSocket) extends State {
     socket.close()
     subscriber.onComplete()
 
+    override def isSubscribed: Boolean                                 = true
     override def enqueue(message: ByteString): Unit                    = fail()
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = fail()
-    override def addDemand(n: Long): Unit                              = {}
-    override def close(): Unit                                         = {}
+    override def addDemand(n: Long): Unit                              = fail()
+    override def complete(): Unit                                      = {}
+    override def cancel(): Unit                                        = fail()
     override def error(exception: Throwable): Unit                     = fail()
 
     private def fail(): Unit = {
@@ -253,18 +515,47 @@ private object WebSocketStreamBuffer {
     }
   }
 
-  case class Failed(
-      exception: Throwable,
-      subscriber: Option[Subscriber[_]] = None
-  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+  /**
+   * State when a subscriber is attached and cancelled, causing the socket to be closed and any queued messages to be
+   * discarded
+   *
+   * This is the alternate terminal state. Transitioning to this state closes the socket.
+   */
+  case class Cancelled()(implicit socket: WebSocket) extends State {
+    socket.close()
+
+    override def isSubscribed: Boolean                                 = true
+    override def enqueue(message: ByteString): Unit                    = {}
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = fail()
+    override def addDemand(n: Long): Unit                              = fail()
+    override def complete(): Unit                                      = {}
+    override def cancel(): Unit                                        = {}
+    override def error(exception: Throwable): Unit                     = fail()
+
+    private def fail(): Unit = {
+      throw new UnsupportedOperationException("Buffer is cancelled")
+    }
+  }
+
+  /**
+   * State when the buffer has failed for any reason, causing the socket to be closed, the subscriber to be
+   * completed with an error, and any queued messages to be discarded
+   *
+   * This is the failed terminal state. Transitioning to this state closes the socket with a failure code and errors
+   * the subscriber if one is attached. A subscriber can be attached after failure in case the buffer fails before the
+   * stream is set up, in which case the subscriber is immediately errored with the exception.
+   */
+  case class Failed(exception: Throwable, subscriber: Option[Subscriber[_]] = None)(implicit socket: WebSocket)
       extends State {
     socket.close(ApplicationFailureCode)
     subscriber.foreach(_.onError(exception))
 
+    override def isSubscribed: Boolean                                 = subscriber.isDefined
     override def enqueue(message: ByteString): Unit                    = {}
     override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = subscriber.onError(exception)
     override def addDemand(n: Long): Unit                              = {}
-    override def close(): Unit                                         = {}
+    override def complete(): Unit                                      = {}
+    override def cancel(): Unit                                        = {}
     override def error(exception: Throwable): Unit                     = {}
   }
 

--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketStreamBuffer.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketStreamBuffer.scala
@@ -1,0 +1,271 @@
+package com.lightbend.lagom.internal.client
+
+import akka.stream.BufferOverflowException
+import akka.util.ByteString
+import com.lightbend.lagom.internal.client.WebSocketStreamBuffer._
+import org.reactivestreams.Subscriber
+import org.scalajs.dom.WebSocket
+
+import scala.collection.mutable
+import scala.scalajs.js.typedarray.ArrayBuffer
+import scala.scalajs.js.typedarray.TypedArrayBuffer
+
+private[lagom] class WebSocketStreamBuffer(
+    socket: WebSocket,
+    bufferSize: Int,
+    deserializeException: (Int, ByteString) => Throwable
+) {
+  private var state: State = Queueing(bufferSize)(this, socket)
+
+  // Forward messages from the socket to the buffer
+  socket.onmessage = { message =>
+    // The message data should be either an ArrayBuffer or a String
+    // It should not be a Blob because the socket binaryType was set
+    val data = message.data match {
+      case buffer: ArrayBuffer => ByteString.apply(TypedArrayBuffer.wrap(buffer))
+      case data                => ByteString.fromString(data.toString)
+    }
+
+    this.enqueue(data)
+  }
+
+  // Fail the buffer and ultimately the stream with an error if the socket encounters an error
+  socket.onerror = { event =>
+    this.error(new RuntimeException(s"WebSocket error: ${event.`type`}"))
+  }
+
+  // Complete the buffer and ultimately the stream when the socket closes based on the close code
+  // The buffer will ensure that pending elements are delivered before downstream completion
+  socket.onclose = { event =>
+    if (event.code == NormalClosure) {
+      this.close()
+    } else {
+      // Fail because the socket closed with an error
+      // Parse the error reason as an exception
+      val bytes     = ByteString.fromString(event.reason)
+      val exception = deserializeException(event.code, bytes)
+      this.error(exception)
+    }
+  }
+
+  def attach(subscriber: Subscriber[_ >: ByteString]): Unit = state.attach(subscriber)
+  def addDemand(n: Long): Unit                              = state.addDemand(n)
+
+  private def enqueue(message: ByteString): Unit = state.enqueue(message)
+  private def close(): Unit                      = state.close()
+  private def error(exception: Throwable): Unit  = state.error(exception)
+
+  private def transition(next: State): Unit = state = next
+}
+
+private object WebSocketStreamBuffer {
+  val NormalClosure          = 1000
+  val ApplicationFailureCode = 4000
+
+  sealed trait State {
+    def enqueue(message: ByteString): Unit
+    def attach(subscriber: Subscriber[_ >: ByteString]): Unit
+    def addDemand(n: Long): Unit
+    def close(): Unit
+    def error(exception: Throwable): Unit
+  }
+
+  sealed trait QueueSize {
+    def bufferSize: Int
+    def queue: mutable.Queue[ByteString]
+
+    protected def checkSize: Option[Throwable] = {
+      if ((queue.size + 1) > bufferSize) Some(BufferOverflowException(s"Exceeded buffer size of $bufferSize"))
+      else None
+    }
+  }
+
+  sealed trait Fulfill {
+    def queue: mutable.Queue[ByteString]
+    def subscriber: Subscriber[_ >: ByteString]
+
+    protected def fulfill(demand: Long): Long = {
+      val num = Math.min(queue.size, demand)
+      for (_ <- 1L to num) subscriber.onNext(queue.dequeue)
+
+      demand - num
+    }
+  }
+
+  case class Queueing(bufferSize: Int)(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State
+      with QueueSize {
+    val queue: mutable.Queue[ByteString] = mutable.Queue.empty
+
+    override def enqueue(message: ByteString): Unit = {
+      checkSize.fold[Unit]({
+        queue.enqueue(message)
+      })(exception => {
+        val failed = Failed(exception)
+        buffer.transition(failed)
+      })
+    }
+
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
+      val streaming = Streaming(queue, bufferSize, subscriber)
+      buffer.transition(streaming)
+    }
+
+    override def addDemand(n: Long): Unit = {
+      val exception = new UnsupportedOperationException("No subscriber is attached")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def close(): Unit = {
+      val full = Full(queue)
+      buffer.transition(full)
+    }
+
+    override def error(exception: Throwable): Unit = {
+      val failed = Failed(exception)
+      buffer.transition(failed)
+    }
+  }
+
+  case class Full(queue: mutable.Queue[ByteString])(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State {
+
+    override def enqueue(message: ByteString): Unit = {
+      val exception = new UnsupportedOperationException("Can not add messages after the buffer is closed")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
+      val draining = Draining(queue, subscriber)
+      buffer.transition(draining)
+    }
+
+    override def addDemand(n: Long): Unit = {
+      val exception = new UnsupportedOperationException("No subscriber is attached")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def close(): Unit = {}
+
+    override def error(exception: Throwable): Unit = {
+      val failed = Failed(exception)
+      buffer.transition(failed)
+    }
+  }
+
+  case class Streaming(
+      queue: mutable.Queue[ByteString],
+      bufferSize: Int,
+      subscriber: Subscriber[_ >: ByteString]
+  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State
+      with QueueSize
+      with Fulfill {
+    private var demand = 0L
+
+    override def enqueue(message: ByteString): Unit = {
+      checkSize.fold[Unit]({
+        queue.enqueue(message)
+        demand = fulfill(demand)
+      })(exception => {
+        val failed = Failed(exception, Some(subscriber))
+        buffer.transition(failed)
+      })
+    }
+
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
+      val exception = new UnsupportedOperationException("Buffer already has attached subscriber")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def addDemand(n: Long): Unit = {
+      demand = fulfill(demand + n)
+    }
+
+    override def close(): Unit = {
+      val state: State = {
+        if (queue.nonEmpty) Draining(queue, subscriber, demand)
+        else Completed(subscriber)
+      }
+      buffer.transition(state)
+    }
+
+    override def error(exception: Throwable): Unit = {
+      val failed = Failed(exception, Some(subscriber))
+      buffer.transition(failed)
+    }
+  }
+
+  case class Draining(
+      queue: mutable.Queue[ByteString],
+      subscriber: Subscriber[_ >: ByteString],
+      initialDemand: Long = 0L
+  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State
+      with Fulfill {
+    private var demand = initialDemand
+
+    override def enqueue(message: ByteString): Unit = {
+      val exception = new UnsupportedOperationException("Can not add messages after the buffer is closed")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = {
+      val exception = new UnsupportedOperationException("Buffer already has attached subscriber")
+      val failed    = Failed(exception)
+      buffer.transition(failed)
+    }
+
+    override def addDemand(n: Long): Unit = {
+      demand = fulfill(demand + n)
+      if (queue.isEmpty) {
+        val completed = Completed(subscriber)
+        buffer.transition(completed)
+      }
+    }
+
+    override def close(): Unit = {}
+
+    override def error(exception: Throwable): Unit = {
+      val failed = Failed(exception, Some(subscriber))
+      buffer.transition(failed)
+    }
+  }
+
+  case class Completed(subscriber: Subscriber[_])(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State {
+    socket.close()
+    subscriber.onComplete()
+
+    override def enqueue(message: ByteString): Unit                    = fail()
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = fail()
+    override def addDemand(n: Long): Unit                              = {}
+    override def close(): Unit                                         = {}
+    override def error(exception: Throwable): Unit                     = fail()
+
+    private def fail(): Unit = {
+      throw new UnsupportedOperationException("Buffer is complete")
+    }
+  }
+
+  case class Failed(
+      exception: Throwable,
+      subscriber: Option[Subscriber[_]] = None
+  )(implicit buffer: WebSocketStreamBuffer, socket: WebSocket)
+      extends State {
+    socket.close(ApplicationFailureCode)
+    subscriber.foreach(_.onError(exception))
+
+    override def enqueue(message: ByteString): Unit                    = {}
+    override def attach(subscriber: Subscriber[_ >: ByteString]): Unit = subscriber.onError(exception)
+    override def addDemand(n: Long): Unit                              = {}
+    override def close(): Unit                                         = {}
+    override def error(exception: Throwable): Unit                     = {}
+  }
+
+}


### PR DESCRIPTION
…which can cause lost elements. 

In my case making a call to `ServiceCall[NotUsed,Source[String,NotUsed]]` like `myService.myServiceCall.invoke().flatMap(_.runWith(Sink.seq))` caused a delay of ~30ms between opened websocket and connected subscriber. All elements in between were lost.

Also don't push more elements to subscriber than requested.

Annoying that JS Websockets don't support backpressure :(