### PR TITLE
Lagom 1.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lagom.js is built against specific versions of Lagom, the latest are:
 |-------------|-------|-----------------|----------|
 | 0.1.2-1.5.5 | 1.5.5 | 2.11 <br> 2.12  | 0.6.31   |
 | 0.3.2-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 0.6.33   |
-| 0.5.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.5.0-1.6.5 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 
 Lagom.js moved to Scala.js 1.x starting with version `0.4.0-1.6.2`. Scala.js 0.6 is no longer supported, the last version to support it was `0.3.2-1.6.2`. For all past releases, see [releases](#Releases).
 
@@ -27,7 +27,7 @@ Lagom.js provides JavaScript versions of several Lagom artifacts. The two most i
 The `lagomjs-scaladsl-api` artifact provides the JavaScript implementation of the Lagom service API:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.5"
 ```
 
 To use it you'll need to configure your service API as a [Scala.js cross project](https://github.com/portable-scala/sbt-crossproject) for the JVM and JS platforms. Then, add the `lagomjs-scaladsl-api` dependency to the JS platform:
@@ -39,7 +39,7 @@ lazy val `service-api` = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies += lagomScaladslApi
   )
   .jsSettings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.0-1.6.5"
   )
 ```
 
@@ -50,7 +50,7 @@ This enables your Lagom service definition to be compiled into JavaScript. In ad
 The `lagomjs-scaladsl-client` artifact provides the JavaScript implementation of the Lagom service client:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.4"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.5"
 ```
 
 You can use it in a Scala.js project along with your service API to generate a service client:
@@ -58,7 +58,7 @@ You can use it in a Scala.js project along with your service API to generate a s
 ```scala
 lazy val `client-js` = project
   .settings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.4"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.0-1.6.5"
   )
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(`service-api`.js)
@@ -161,3 +161,4 @@ Lagom.js tracks Lagom and generally doesn't continue development on previous Lag
 | 0.4.0-1.6.3 | 1.6.3 | 2.12 <br> 2.13  | 1.1.1    |
 | 0.4.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 | 0.5.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.5.0-1.6.5 | 1.6.5 | 2.12 <br> 2.13  | 1.2.0    |

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 val scalaVersions = Seq("2.12.13", "2.13.4")
 
 val baseLagomVersion = "1.6.5"
-val akkaJsVersion    = "2.2.6.9"
+val akkaJsVersion    = "2.2.6.14"
 
 lazy val scalaSettings = Seq(
   crossScalaVersions := scalaVersions,

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbt.Keys.version
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val scalaVersions = Seq("2.12.10", "2.13.1")
+val scalaVersions = Seq("2.12.13", "2.13.4")
 
-val baseLagomVersion = "1.6.4"
+val baseLagomVersion = "1.6.5"
 val akkaJsVersion    = "2.2.6.9"
 
 lazy val scalaSettings = Seq(
@@ -50,7 +50,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
   organization := "com.github.mliarakos.lagomjs",
-  version := s"0.5.1-$baseLagomVersion-SNAPSHOT"
+  version := s"0.5.0-$baseLagomVersion-SNAPSHOT"
 )
 
 lazy val commonJsSettings = Seq(


### PR DESCRIPTION
Upgrade to [Lagom 1.6.5](https://github.com/lagom/lagom/releases/tag/1.6.5). Resolves #23.

Waiting on https://github.com/akka-js/akka.js/pull/127 to upgrade Akka.js. Only upgraded to Scala 1.3.4 because Scala 1.3.5 isn't supported by Scala.js 1.2.0. A future point release will upgrade Scala.js to 1.5.0 to get to Scala 1.3.5.