### PR TITLE
use encodeURIComponent instead of URLEncoder.encode for path components

### DIFF
--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
@@ -23,6 +23,7 @@ import play.api.libs.streams.AkkaStreams
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.scalajs.js.URIUtils
 
 private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
     serviceName: String,
@@ -51,7 +52,7 @@ private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
           queryParams
             .flatMap {
               case (name, values) =>
-                values.map(value => URLEncoder.encode(name, "utf-8") + "=" + URLEncoder.encode(value, "utf-8"))
+                values.map(value => URIUtils.encodeURIComponent(name) + "=" + URIUtils.encodeURIComponent(value))
             }
             .mkString("?", "&", "")
         } else ""


### PR DESCRIPTION
To encode the query string values the akka-js provided java.net.URLEncoder implementation is used, which delegates to global.encodeURI. Instead global.encodeURIComponent should be used as it otherwise leads to different results compared to the JVM implementation and an invalid encoding. E.g.:

```scala
val jvmImpl = java.net.URLEncoder.encode("foo & bar", "utf-8")
jvmImpl : String = foo+%26+bar

val akkaJsImpl = java.net.URLEncoder.encode("foo & bar", "utf-8")
lagomJsImpl : String = moin%20&%20sup

// URIUtils are just a facade to global.encodeURI*
val jsEncodeURIComponent = scala.scalajs.js.URIUtils.encodeURIComponent("moin & sup"))
jsEncodeURIComponent : String = moin%20%26%20sup
```


Only the last result is a valid encoding of a query string, as not encoded & are interpreted as the end of a value.

Note: On the JVM a space is encoded as a plus, in JS as %20. Both are valid encodings though