### PR TITLE
Scalajs dom & other updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbt.Keys.version
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val scalaVersions = Seq("2.12.13", "2.13.4")
+val scalaVersions = Seq("2.12.15", "2.13.7")
 
-val baseLagomVersion = "1.6.5"
+val baseLagomVersion = "1.6.7"
 val akkaJsVersion    = "2.2.6.14"
 
 lazy val scalaSettings = Seq(
@@ -50,7 +50,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
   organization := "com.github.mliarakos.lagomjs",
-  version := s"0.5.0-$baseLagomVersion"
+  version := s"0.6.0-$baseLagomVersion-antex"
 )
 
 lazy val commonJsSettings = Seq(
@@ -182,7 +182,8 @@ lazy val `lagomjs-api-scaladsl` = crossProject(JSPlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-      "org.scalatest"  %%% "scalatest"   % "3.1.4"            % Test
+      "org.scalatest"  %%% "scalatest"   % "3.1.4"            % Test,
+      "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
     )
   )
   .jsSettings(
@@ -240,7 +241,7 @@ lazy val `lagomjs-client` = crossProject(JSPlatform)
   .jsSettings(commonJsSettings: _*)
   .jsSettings(
     libraryDependencies ++= Seq(
-      "org.scala-js"  %%% "scalajs-dom" % "1.1.0",
+      "org.scala-js"  %%% "scalajs-dom" % "2.1.0",
       "org.scalatest" %%% "scalatest"   % "3.1.4" % Test
     )
   )

--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
@@ -23,6 +23,7 @@ import play.api.libs.streams.AkkaStreams
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.scalajs.js.URIUtils
 
 private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
     serviceName: String,
@@ -51,7 +52,7 @@ private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
           queryParams
             .flatMap {
               case (name, values) =>
-                values.map(value => URLEncoder.encode(name, "utf-8") + "=" + URLEncoder.encode(value, "utf-8"))
+                values.map(value => URIUtils.encodeURIComponent(name) + "=" + URIUtils.encodeURIComponent(value))
             }
             .mkString("?", "&", "")
         } else ""

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.2.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.8.0")
 
 addSbtPlugin("com.jsuereth"  % "sbt-pgp"      % "1.1.2")
 addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "1.0.0")


### PR DESCRIPTION
there's a new major binary incompatible version of scalajs-dom. this pull requests updates to the lastet scalajs-dom 2.1 and other chore updates (sbt,scala,lagom,scalajs).

additionally i've included the recommended https://github.com/scala-js/scala-js-macrotask-executor instead of ExecutionContext.global