### PR TITLE
scalajs-dom update & others

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Lagom.js is built against specific versions of Lagom, the latest are:
 |-------------|-------|-----------------|----------|
 | 0.1.2-1.5.5 | 1.5.5 | 2.11 <br> 2.12  | 0.6.31   |
 | 0.3.2-1.6.2 | 1.6.2 | 2.12 <br> 2.13  | 0.6.33   |
-| 0.5.1-1.6.5 | 1.6.5 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.6.0-1.6.7 | 1.6.5 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.6.0-1.6.7 | 1.6.7 | 2.12 <br> 2.13  | 1.8.0    |
 
 Lagom.js moved to Scala.js 1.x starting with version `0.4.0-1.6.2`. Scala.js 0.6 is no longer supported, the last version to support it was `0.3.2-1.6.2`. For all past releases, see [releases](#Releases).
 
@@ -27,7 +28,7 @@ Lagom.js provides JavaScript versions of several Lagom artifacts. The two most i
 The `lagomjs-scaladsl-api` artifact provides the JavaScript implementation of the Lagom service API:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.1-1.6.5"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.6.0-1.6.7"
 ```
 
 To use it you'll need to configure your service API as a [Scala.js cross project](https://github.com/portable-scala/sbt-crossproject) for the JVM and JS platforms. Then, add the `lagomjs-scaladsl-api` dependency to the JS platform:
@@ -39,7 +40,7 @@ lazy val `service-api` = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies += lagomScaladslApi
   )
   .jsSettings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.5.1-1.6.5"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-api" % "0.6.0-1.6.7"
   )
 ```
 
@@ -50,7 +51,7 @@ This enables your Lagom service definition to be compiled into JavaScript. In ad
 The `lagomjs-scaladsl-client` artifact provides the JavaScript implementation of the Lagom service client:
 
 ```sbt
-"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.1-1.6.5"
+"com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.6.0-1.6.7"
 ```
 
 You can use it in a Scala.js project along with your service API to generate a service client:
@@ -58,7 +59,7 @@ You can use it in a Scala.js project along with your service API to generate a s
 ```scala
 lazy val `client-js` = project
   .settings(
-    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.5.1-1.6.5"
+    libraryDependencies += "com.github.mliarakos.lagomjs" %%% "lagomjs-scaladsl-client" % "0.6.0-1.6.7"
   )
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(`service-api`.js)
@@ -163,3 +164,4 @@ Lagom.js tracks Lagom and generally doesn't continue development on previous Lag
 | 0.5.0-1.6.4 | 1.6.4 | 2.12 <br> 2.13  | 1.2.0    |
 | 0.5.0-1.6.5 | 1.6.5 | 2.12 <br> 2.13  | 1.2.0    |
 | 0.5.1-1.6.5 | 1.6.5 | 2.12 <br> 2.13  | 1.2.0    |
+| 0.6.0-1.6.7 | 1.6.7 | 2.12 <br> 2.13  | 1.8.0    |

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbt.Keys.version
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val scalaVersions = Seq("2.12.13", "2.13.4")
+val scalaVersions = Seq("2.12.15", "2.13.7")
 
-val baseLagomVersion = "1.6.5"
+val baseLagomVersion = "1.6.7"
 val akkaJsVersion    = "2.2.6.14"
 
 lazy val scalaSettings = Seq(
@@ -50,7 +50,7 @@ lazy val publishSettings = Seq(
 
 lazy val commonSettings = scalaSettings ++ publishSettings ++ Seq(
   organization := "com.github.mliarakos.lagomjs",
-  version := s"0.5.1-$baseLagomVersion"
+  version := s"0.6.0-$baseLagomVersion"
 )
 
 lazy val commonJsSettings = Seq(
@@ -240,7 +240,7 @@ lazy val `lagomjs-client` = crossProject(JSPlatform)
   .jsSettings(commonJsSettings: _*)
   .jsSettings(
     libraryDependencies ++= Seq(
-      "org.scala-js"  %%% "scalajs-dom" % "1.1.0",
+      "org.scala-js"  %%% "scalajs-dom" % "2.1.0",
       "org.scalatest" %%% "scalatest"   % "3.1.4" % Test
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.2.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.8.0")
 
 addSbtPlugin("com.jsuereth"  % "sbt-pgp"      % "1.1.2")
 addSbtPlugin("org.akka-js"   % "sbt-shocon"   % "1.0.0")


### PR DESCRIPTION
there's a new major binary incompatible version of scalajs-dom. this pull requests updates to the lastet scalajs-dom 2.1 and other chore updates (sbt,scala,lagom,scalajs).