### PR TITLE
Resolved warnings and deprecations from dependency upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 target/
 
+.bsp/
+
 lagomjs-api/shared/
 lagomjs-api-scaladsl/shared/
 lagomjs-client/shared/

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val `lagomjs-api` = crossProject(JSPlatform)
     )
   )
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )
@@ -186,7 +186,7 @@ lazy val `lagomjs-api-scaladsl` = crossProject(JSPlatform)
     )
   )
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )
@@ -208,7 +208,7 @@ lazy val `lagomjs-spi` = crossProject(JSPlatform)
   )
   .jsSettings(commonJsSettings: _*)
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value }
   )
 
@@ -245,7 +245,7 @@ lazy val `lagomjs-client` = crossProject(JSPlatform)
     )
   )
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )
@@ -291,8 +291,8 @@ lazy val `lagomjs-client-scaladsl` = crossProject(JSPlatform)
     )
   )
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
-    compile in Compile := { (compile in Compile).dependsOn(shoconConcat).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(shoconConcat).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )
@@ -328,7 +328,7 @@ lazy val `lagomjs-persistence-scaladsl` = crossProject(JSPlatform)
   )
   .jsSettings(commonJsSettings: _*)
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )
@@ -369,7 +369,7 @@ lazy val `lagomjs-macro-testkit` = crossProject(JSPlatform)
     )
   )
   .jsSettings(
-    compile in Compile := { (compile in Compile).dependsOn(assembleLagomLibrary).value },
+    Compile / compile := { (Compile / compile).dependsOn(assembleLagomLibrary).value },
     publishLocal := { publishLocal.dependsOn(assembleLagomLibrary).value },
     PgpKeys.publishSigned := { PgpKeys.publishSigned.dependsOn(assembleLagomLibrary).value }
   )

--- a/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
+++ b/lagomjs-client-scaladsl/js/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
@@ -4,12 +4,10 @@
 
 package com.lightbend.lagom.scaladsl.client
 
-import java.io.File
-
 import akka.actor.ActorSystem
 import akka.actor.CoordinatedShutdown
-import akka.stream.ActorMaterializer
 import akka.stream.Materializer
+import akka.stream.SystemMaterializer
 import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
 import com.lightbend.lagom.internal.client.WebSocketClientConfig
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactoryProvider
@@ -26,6 +24,7 @@ import play.api.Configuration
 import play.api.Environment
 import play.api.Mode
 
+import java.io.File
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.language.experimental.macros
@@ -202,7 +201,7 @@ abstract class StandaloneLagomClientFactory(
   // TODO: create compatibility layer for ActorSystemProvider?
   override lazy val actorSystem: ActorSystem        = ActorSystem("default", configuration.underlying, environment.classLoader)
   lazy val coordinatedShutdown: CoordinatedShutdown = CoordinatedShutdown(actorSystem)
-  override lazy val materializer: Materializer      = ActorMaterializer.create(actorSystem)
+  override lazy val materializer: Materializer      = SystemMaterializer(actorSystem).materializer
 
   /**
    * Stop this [[LagomClientFactory]] by shutting down the internal [[akka.actor.ActorSystem]] and Akka Streams [[akka.stream.Materializer]].

--- a/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketClient.scala
+++ b/lagomjs-client/js/src/main/scala/com/lightbend/lagom/internal/client/WebSocketClient.scala
@@ -12,8 +12,8 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import org.scalajs.dom.CloseEvent
+import org.scalajs.dom.Event
 import org.scalajs.dom.WebSocket
-import org.scalajs.dom.raw.Event
 import play.api.http.Status
 
 import java.net.URI


### PR DESCRIPTION
Resolved various warnings and deprecations from the upgrades in #30, the main ones are:
- Updated to the SBT slash syntax
- Updated to the new scala-js-dom namespace
- Reimplemented Ajax object from scala-js-dom since it is deprecated in 2.0.0